### PR TITLE
fix(worker): 修正 web_logger 的參數傳遞錯誤

### DIFF
--- a/app/worker.py
+++ b/app/worker.py
@@ -53,7 +53,11 @@ def match_task(tasks: list[Task], task_includes: list, filepath: str) -> Task | 
     for index, include in enumerate(task_includes, start=0):
         if include in filepath:
             task = tasks[index]
-            web_logger(filepath, task)
+            web_logger(
+                task_id=task.id,
+                level="INFO",
+                message=f'檔案 "{filepath}" 與任務 "{task.name}" 匹配成功',
+            )
             return task
     return None
 


### PR DESCRIPTION
在 match_task 函式中，先前對 web_logger 的呼叫傳遞了錯誤的參數。本次提交修正了此問題，確保傳遞正確的 task_id、日誌級別和訊息，使日誌記錄恢復正常。